### PR TITLE
debug#option.py

### DIFF
--- a/pocsuite/lib/core/option.py
+++ b/pocsuite/lib/core/option.py
@@ -200,19 +200,20 @@ def setMultipleTarget():
 
     if not conf.urlFile:
         for pocname, pocInstance in kb.registeredPocs.items():
+            target_urls = []
             if conf.url.endswith('/24'):
                 try:
                     socket.inet_aton(conf.url.split('/')[0])
                     base_addr = conf.url[:conf.url.rfind('.') + 1]
-                    conf.url = ['{}{}'.format(base_addr, i) \
+                    target_urls = ['{}{}'.format(base_addr, i) \
                                         for i in xrange(1, 255 + 1)]
                 except socket.error:
                     errMsg = 'only id address acceptable'
                     logger.log(CUSTOM_LOGGING.ERROR, errMsg)
             else:
-                conf.url = conf.url.split(',')
+                target_urls = conf.url.split(',')
 
-            for url in conf.url:
+            for url in target_urls:
                 if url:
                     kb.targets.put((url, pocInstance, pocname))
 


### PR DESCRIPTION
debug#命令行指定 -r /tmp/poc文件夹下多个poc时候，原始203行左右，第一次for循环进入 conf.url.endswith('/24'): conf.url是str，可以endswith，但是在循环内部，conf.url被赋值为 list， 再次进入for循环，程序conf.url.endswith 出错退出。
出错参考命令: python pocsuite.py -r /tmp/poc -u http://www.baidu.com --verify   注: poc 文件夹下 有 2个或者多个poc文件时候出错。