### PR TITLE
Fix concatenating mismatched type bug

### DIFF
--- a/pocsuite/lib/controller/controller.py
+++ b/pocsuite/lib/controller/controller.py
@@ -92,7 +92,7 @@ def pocThreads():
             result = poc.execute(target, headers=conf.httpHeaders, mode=conf.mode, params=conf.params, verbose=True)
             if not result:
                 continue
-            result_error = "Error," + result.error[1] if result.error[1] else "failed"
+            result_error = "Error: {}".format(result.error[1]) if result.error[1] else "failed"
             output = (target, pocname, result.vulID, result.appName, result.appVersion, "success" if result.is_success() else result_error, time.strftime("%Y-%m-%d %X", time.localtime()), str(result.result))
             result.show_result()
 


### PR DESCRIPTION
Here I got the following exception because of concatenating mismatched type（python 2.7.11）:
```python
 File "/home/jetz/Desktop/pocsuite/pocsuite/lib/controller/controller.py", line 95, in pocThreads
    result_error = "Error," + result.error[1] if result.error[1] else "failed"
TypeError: cannot concatenate 'str' and 'exceptions.ValueError' objects
````

