### PR TITLE
AttributeError: Seebug instance has no attribute 'parser'

### DIFF
--- a/pocsuite/api/x.py
+++ b/pocsuite/api/x.py
@@ -60,7 +60,7 @@ class ZoomEye():
 
     def write_conf(self):
         if not self.parser.has_section("zoomeye"):
-            self.parse.add_section("zoomeye")
+            self.parser.add_section("zoomeye")
 
         username = raw_input("ZoomEye Email:")
         password = raw_input("ZoomEye Password:")


### PR DESCRIPTION
and use `os.path.join(path1,".rc")` instead of `path1 + "/.rc"`