### PR TITLE
Fix #pocsuite-issue-99

### DIFF
--- a/pocsuite/lib/core/consoles.py
+++ b/pocsuite/lib/core/consoles.py
@@ -49,9 +49,10 @@ def initializePoc(folders):
     if not os.path.isdir(paths.POCSUITE_MODULES_PATH):
         os.makedirs(paths.POCSUITE_MODULES_PATH)
     folders.append(paths.POCSUITE_MODULES_PATH)
+    folders = [_ for _ in folders if os.path.isdir(_)]
+
     for folder in folders:
-        files = os.listdir(folder)
-        for file in files:
+        for file in os.listdir(folder):
             if file.endswith(".py") or file.endswith('.json') and "__init__" not in file:
                 pocNumber += 1
                 kb.unloadedList.update({pocNumber: os.path.join(folder, file)})


### PR DESCRIPTION
https://github.com/knownsec/Pocsuite/issues/99

**issue**

```
$ ./pcs-console.py -h
Traceback (most recent call last):
  File "./pcs-console.py", line 15, in <module>
    sys.exit(main())
  File "/Users/Open-Security/Code/ks-pocsuite/pocsuite/pocsuite_console.py", line 27, in main
    initializePoc(folders)
  File "/Users/Open-Security/Code/ks-pocsuite/pocsuite/lib/core/consoles.py", line 53, in initializePoc
    files = os.listdir(folder)
OSError: [Errno 2] No such file or directory: '-h'
```

**Fix**

```
$ ./pcs-console.py -h

                              ,--. ,--.
 ,---. ,---. ,---.,---.,--.,--`--,-'  '-.,---.  {2.0.4.1-782b2aa}
| .-. | .-. | .--(  .-'|  ||  ,--'-.  .-| .-. :
| '-' ' '-' \ `--.-'  `'  ''  |  | |  | \   --.
|  |-' `---' `---`----' `----'`--' `--'  `----'
`--'                                            http://pocsuite.org

Pcs>

```