### PR TITLE
检测 PHP 文件上传是否成功的例子代码存在问题

### DIFF
--- a/docs/CODING.md
+++ b/docs/CODING.md
@@ -318,7 +318,7 @@ JSON 格式的 PoC 类似于完形填空,只需要填写相应的字段的值即
         检测 PHP 文件上传是否成功,
 
             token = randomStr()
-            payload = '<?php echo md5(%s);unlink(__FILE__);?>' % token
+            payload = '<?php echo md5("%s");unlink(__FILE__);?>' % token
             ...
 
             if hashlib.new('md5', token).hexdigest() in content:


### PR DESCRIPTION
如果%s不加引号，并且randomStr()生成的随机字符串是数字开头，则md5会失败。文件上传成功但验证失败，则上传的文件没有自动删除。所以以前用到这种方式的poc都要检查修正一下。