### PR TITLE
Output Error details instead of <Error: n>

### DIFF
--- a/pocsuite/api/x.py
+++ b/pocsuite/api/x.py
@@ -53,7 +53,7 @@ class ZoomEye():
 
     def search(self, dork, page=1, resource='web'):
         req = requests.get(
-            'https://api.zoomeye.org/{}/search?query={}&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
+            'https://api.zoomeye.org/{}/search?query="{}"&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
             headers=self.headers
         )
         content = json.loads(req.content)

--- a/pocsuite/api/x.py
+++ b/pocsuite/api/x.py
@@ -53,7 +53,7 @@ class ZoomEye():
 
     def search(self, dork, page=1, resource='web'):
         req = requests.get(
-            'https://api.zoomeye.org/{}/search?query="{}"&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
+            'https://api.zoomeye.org/{}/search?query={}&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
             headers=self.headers
         )
         content = json.loads(req.content)

--- a/pocsuite/lib/core/poc.py
+++ b/pocsuite/lib/core/poc.py
@@ -154,7 +154,7 @@ class Output(object):
     '''
 
     def __init__(self, poc=None):
-        self.error = ''
+        self.error = tuple()
         self.result = {}
         self.status = OUTPUT_STATUS.FAILED
         if poc:
@@ -177,13 +177,11 @@ class Output(object):
     def fail(self, error=""):
         self.status = OUTPUT_STATUS.FAILED
         assert isinstance(error, types.StringType)
-        if type(self.error) == str:
-            error = (0, None)
-        self.error = error
+        self.error = (0, error)
 
     def error(self, error=""):
         self.expt = (ERROR_TYPE_ID.OTHER, error)
-        self.error = error
+        self.error = (0, error)
 
     def show_result(self):
         if self.status == OUTPUT_STATUS.SUCCESS:


### PR DESCRIPTION
pocThreads function in lib/controller/controller.py file:
fetch error in result, as follow
`result_error = "Error: {}".format(result.error[1]) if result.error[1] else "failed"`
so, result.error's type not be string, may be tuple?
           