### PR TITLE
fix/zoomeye api dork request

### DIFF
--- a/pocsuite/api/x.py
+++ b/pocsuite/api/x.py
@@ -53,7 +53,7 @@ class ZoomEye():
 
     def search(self, dork, page=1, resource='web'):
         req = requests.get(
-            'https://api.zoomeye.org/{}/search?query="{}"&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
+            'https://api.zoomeye.org/{}/search?query={}&page={}&facet=app,os'.format(resource, urllib.quote(dork), page + 1),
             headers=self.headers
         )
         content = json.loads(req.content)


### PR DESCRIPTION
删除query参数多余的双引号