### PR TITLE
删除了registerPoc中对poc是否在kb中的判断

### DIFF
--- a/pocsuite/lib/core/register.py
+++ b/pocsuite/lib/core/register.py
@@ -19,8 +19,6 @@ from pocsuite.lib.core.common import StringImporter
 
 def registerPoc(pocClass):
     module = pocClass.__module__.split('.')[-1]
-    if module in kb.registeredPocs:
-        return
 
     kb.registeredPocs[module] = pocClass()
 


### PR DESCRIPTION
每次实例化poc，避免多线程中多个扫描ip公用一个poc导致self.url变量相同的一些问题