### PR TITLE
fix path err on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .svn
 .tox
 .idea/
+.vscode
 bin
 build
 dist

--- a/pocsuite/lib/controller/controller.py
+++ b/pocsuite/lib/controller/controller.py
@@ -10,6 +10,7 @@ import os
 import time
 import shutil
 import tempfile
+import platform
 from textwrap import dedent
 from pocsuite.lib.core.settings import REPORT_HTMLBASE
 from pocsuite.lib.core.settings import REPORT_TABLEBASE
@@ -135,6 +136,11 @@ def _setRecordFiles():
         if type(status) != str:
             status = status[1]
         outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(target)))
+        # colon is illegal in windows file system
+        if "Windows" in platform.platform():
+            # replace colon between ip and port as "-", avoid unicode replace error
+            # bypass the first colon in drive letter like "C:\"
+            outputPath = outputPath[:4] + outputPath[4:].replace(":", "-")
 
         if not os.path.isdir(outputPath):
             try:


### PR DESCRIPTION
修复在 windows 系统上因为文件名中不能存在冒号而导致的报错
![image](https://user-images.githubusercontent.com/5460009/35959139-426a3a70-0cdf-11e8-811a-dbe547b54f74.png)
