### PR TITLE
编写dork模块用于抓取目标地址

### DIFF
--- a/modules/360so-dork.py
+++ b/modules/360so-dork.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import pychrome
+import urlparse
+from pocsuite.api.poc import register
+from pocsuite.api.poc import Output, POCBase
+from pocsuite.lib.core.data import paths,logger
+from pocsuite.lib.core.common import getUnicode
+from pocsuite.lib.core.common import normalizeUnicode
+from pocsuite.lib.core.enums import CUSTOM_LOGGING
+
+
+# 环境配置:
+# 	本地配置chrome的headless，执行如下命令:
+# 	headless mode (chrome version >= 59):
+# 	$ google-chrome --headless --disable-gpu --remote-debugging-port=9222
+
+# 	或者直接使用docker
+# 	$ docker pull fate0/headless-chrome
+# 	$ docker run -it --rm --cap-add=SYS_ADMIN -p9222:9222 fate0/headless-chrome
+
+# 	PS:使用google-dork等需要那啥的时候打开ss就好
+
+# 使用说明:
+# 	对目标使用搜索dork语法，程序会返回抓取的域名
+# 	python pocsuite.py -r modules/360so-dork.py -u site:i.mi.com --verify
+# 	默认对域名做了去重输出，根据需要可以修改script
+
+
+class Dork(POCBase):
+	vulID = '0'  # ssvid
+	version = '1.0'
+	author = ['z3r0yu']
+	vulDate = '2018-12-22'
+	createDate = '2018-12-22'
+	updateDate = '2018-12-22'
+	references = ['https://zeroyu.xyz/']
+	name = '360so dork'
+	appPowerLink = 'https://www.so.com/'
+	appName = '360so-dork'
+	appVersion = '1'
+	vulType = 'search dork'
+	desc = '''
+	   使用chrome headless对使用360so搜索引擎的搜索结果进行抓取
+	'''
+	samples = ['site:i.mi.com']
+	install_requires = ['pychrome']
+
+
+	def SearchDork(self,target):
+
+		# create a browser instance
+		browser = pychrome.Browser(url="http://127.0.0.1:9222")
+
+		# create a tab
+		tab = browser.new_tab()
+
+		# start the tab
+		tab.start()
+		tab.Page.enable()
+		# call method
+		tab.Network.enable()
+		tab.Runtime.enable()
+
+		step=1
+
+		subdomins=[]
+
+		while(1):
+
+			url="https://www.so.com/s?q={}".format(target)
+			url=url+"&pn={}".format(step)
+			step=step+1
+
+			try:
+				# call method with timeout
+				tab.Page.navigate(url=url, _timeout=5)
+				tab.wait(5)
+
+				exp='document.getElementsByClassName("res-title").length'
+				length= tab.Runtime.evaluate(expression=exp)		
+
+				# 360so就看报不报错，报错了的话document.getElementsByClassName("res-title").length是为0的
+				if length['result']['value']==0:
+					break
+
+				#从每一页上抓取url
+				for l in range(0,length['result']['value']):
+					# tab.wait(1)
+					exp1='document.getElementsByClassName("res-title")[{}].getElementsByTagName("a")[0].href'.format(l)
+					res1= tab.Runtime.evaluate(expression=exp1)
+					# print res1['result']['value']
+					subdomins.append(res1['result']['value'])
+			except:
+				pass
+
+		tab.stop()
+		browser.close_tab(tab)
+		return subdomins
+
+
+	def _output2file(self,outputPath,msg):
+		with open(outputPath,'a') as f:
+			for m in msg:
+				f.write(m + '\n')
+
+	def _attack(self):
+		return self._verify() 
+
+	def _verify(self):
+		result = {}
+		DorkGrammar = self.url.replace("http://","")
+		subdomins=self.SearchDork(DorkGrammar)
+		tmp=[]
+		for sub in subdomins:
+			url=urlparse.urlparse(sub)
+			tmp.append(url.scheme+"://"+url.netloc)
+		# 去重
+		subdomins=list(set(tmp))
+		result['VerifyInfo'] = {}
+		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
+		outputPath = os.path.join(outputPath,"so2result.txt")
+		j=1
+		if subdomins:
+			self._output2file(outputPath,subdomins)	
+			for s in subdomins:
+				t="URL"+str(j)
+				result['VerifyInfo'][t] = s
+				j=j+1
+		outputPathInfo="outpath:"+outputPath
+		logger.log(CUSTOM_LOGGING.SYSINFO, outputPathInfo)
+		return self.parse_output(result)
+
+	def parse_output(self, result):
+		#parse output
+		output = Output(self)
+		if result['VerifyInfo']:
+			output.success(result)
+		else:
+			output.fail('Find nothing or Internet error~')
+		return output
+
+
+register(Dork)

--- a/modules/360so-dork.py
+++ b/modules/360so-dork.py
@@ -4,6 +4,8 @@
 import os
 import pychrome
 import urlparse
+import tempfile
+import platform
 from pocsuite.api.poc import register
 from pocsuite.api.poc import Output, POCBase
 from pocsuite.lib.core.data import paths,logger
@@ -102,10 +104,27 @@ class Dork(POCBase):
 
 
 	def _output2file(self,outputPath,msg):
-		with open(outputPath,'a') as f:
+
+		if "Windows" in platform.platform():
+			outputPath = outputPath[:4] + outputPath[4:].replace(":", "-")
+
+		if not os.path.isdir(outputPath):
+			try:
+				os.makedirs(outputPath, 0755)
+			except:
+				print "guess what?!"
+
+		recordFile = os.path.join(outputPath, "so2result.txt")
+
+		if not os.path.isfile(recordFile):
+			with open(recordFile, "w") as f:
+				for m in msg:
+					f.write(m + '\n')
+			return
+
+		with open(recordFile,'a+') as f:
 			for m in msg:
 				f.write(m + '\n')
-
 	def _attack(self):
 		return self._verify() 
 
@@ -120,8 +139,9 @@ class Dork(POCBase):
 		# 去重
 		subdomins=list(set(tmp))
 		result['VerifyInfo'] = {}
+
 		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
-		outputPath = os.path.join(outputPath,"so2result.txt")
+		# outputPath = os.path.join(outputPath,"so2result.txt")
 		j=1
 		if subdomins:
 			self._output2file(outputPath,subdomins)	

--- a/modules/bing-dork.py
+++ b/modules/bing-dork.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import pychrome
+import urlparse
+from pocsuite.api.poc import register
+from pocsuite.api.poc import Output, POCBase
+from pocsuite.lib.core.data import paths,logger
+from pocsuite.lib.core.common import getUnicode
+from pocsuite.lib.core.common import normalizeUnicode
+from pocsuite.lib.core.enums import CUSTOM_LOGGING
+
+
+# 环境配置:
+# 	本地配置chrome的headless，执行如下命令:
+# 	headless mode (chrome version >= 59):
+# 	$ google-chrome --headless --disable-gpu --remote-debugging-port=9222
+
+# 	或者直接使用docker
+# 	$ docker pull fate0/headless-chrome
+# 	$ docker run -it --rm --cap-add=SYS_ADMIN -p9222:9222 fate0/headless-chrome
+
+# 	PS:使用google-dork等需要那啥的时候打开ss就好
+
+# 使用说明:
+# 	对目标使用搜索dork语法，程序会返回抓取的域名
+# 	python pocsuite.py -r modules/bing-dork.py -u site:i.mi.com --verify
+# 	默认对域名做了去重输出，根据需要可以修改script
+
+
+class Dork(POCBase):
+	vulID = '0'  # ssvid
+	version = '1.0'
+	author = ['z3r0yu']
+	vulDate = '2018-12-22'
+	createDate = '2018-12-22'
+	updateDate = '2018-12-22'
+	references = ['https://zeroyu.xyz/']
+	name = 'bing dork'
+	appPowerLink = 'https://www.bing.com/'
+	appName = 'bing-dork'
+	appVersion = '1'
+	vulType = 'search dork'
+	desc = '''
+	   使用chrome headless对使用bing搜索引擎的搜索结果进行抓取
+	'''
+	samples = ['site:i.mi.com']
+	install_requires = ['pychrome']
+
+
+	def SearchDork(self,target):
+
+		# create a browser instance
+		browser = pychrome.Browser(url="http://127.0.0.1:9222")
+
+		# create a tab
+		tab = browser.new_tab()
+
+		# start the tab
+		tab.start()
+
+		tab.Page.enable()
+
+		# call method
+		tab.Network.enable()
+		tab.Runtime.enable()
+
+		#bing最多也是1000
+		start=1000
+
+		subdomins=[]
+
+		for step in range(0,start+10,10):
+
+			url="https://www.bing.com/search?q={}".format(target)
+			url=url+"&first={}".format(step)
+			# stepinfo="step:"+str(step)
+			# logger.info(stepinfo)
+
+			try:
+				# call method with timeout
+				tab.Page.navigate(url=url, _timeout=5)
+				tab.wait(5)
+
+				exp='document.getElementsByClassName("b_algo").length'
+				length= tab.Runtime.evaluate(expression=exp)
+
+				if length['result']['value']==0:
+					break
+		
+				#从每一页上抓取url
+				for l in range(0,length['result']['value']):
+					exp1='document.getElementsByClassName("b_algo")[{}].getElementsByTagName("a")[0].href'.format(l)
+					res1= tab.Runtime.evaluate(expression=exp1)
+					logger.info(res1['result']['value'])
+					subdomins.append(res1['result']['value'])
+
+			except:
+				pass
+
+
+		tab.stop()
+		browser.close_tab(tab)
+		return subdomins
+
+
+	def _output2file(self,outputPath,msg):
+		with open(outputPath,'a') as f:
+			for m in msg:
+				f.write(m + '\n')
+
+	def _attack(self):
+		return self._verify() 
+
+	def _verify(self):
+		result = {}
+		DorkGrammar = self.url.replace("http://","")
+		subdomins=self.SearchDork(DorkGrammar)
+		tmp=[]
+		for sub in subdomins:
+			url=urlparse.urlparse(sub)
+			tmp.append(url.scheme+"://"+url.netloc)
+		# 去重
+		subdomins=list(set(tmp))
+		result['VerifyInfo'] = {}
+		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
+		outputPath = os.path.join(outputPath,"bing2result.txt")
+		j=1
+		if subdomins:
+			self._output2file(outputPath,subdomins)	
+			for s in subdomins:
+				t="URL"+str(j)
+				result['VerifyInfo'][t] = s
+				j=j+1
+		outputPathInfo="outpath:"+outputPath
+		logger.log(CUSTOM_LOGGING.SYSINFO, outputPathInfo)
+		return self.parse_output(result)
+
+	def parse_output(self, result):
+		#parse output
+		output = Output(self)
+		if result['VerifyInfo']:
+			output.success(result)
+		else:
+			output.fail('Find nothing or Internet error~')
+		return output
+
+
+register(Dork)

--- a/modules/google-dork.py
+++ b/modules/google-dork.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import pychrome
+import urlparse
+from pocsuite.api.poc import register
+from pocsuite.api.poc import Output, POCBase
+from pocsuite.lib.core.data import paths,logger
+from pocsuite.lib.core.common import getUnicode
+from pocsuite.lib.core.common import normalizeUnicode
+from pocsuite.lib.core.enums import CUSTOM_LOGGING
+
+
+# 环境配置:
+# 	本地配置chrome的headless，执行如下命令:
+# 	headless mode (chrome version >= 59):
+# 	$ google-chrome --headless --disable-gpu --remote-debugging-port=9222
+
+# 	或者直接使用docker
+# 	$ docker pull fate0/headless-chrome
+# 	$ docker run -it --rm --cap-add=SYS_ADMIN -p9222:9222 fate0/headless-chrome
+
+# 	PS:使用google-dork等需要那啥的时候打开ss就好
+
+# 使用说明:
+# 	对目标使用搜索dork语法，程序会返回抓取的域名
+# 	python pocsuite.py -r modules/google-dork.py -u site:i.mi.com --verify
+# 	默认对域名做了去重输出，根据需要可以修改script
+
+
+class Dork(POCBase):
+	vulID = '0'  # ssvid
+	version = '1.0'
+	author = ['z3r0yu']
+	vulDate = '2018-12-22'
+	createDate = '2018-12-22'
+	updateDate = '2018-12-22'
+	references = ['https://zeroyu.xyz/']
+	name = 'google dork'
+	appPowerLink = 'https://www.google.com/'
+	appName = 'google-dork'
+	appVersion = '1'
+	vulType = 'search dork'
+	desc = '''
+	   使用chrome headless对使用google搜索引擎的搜索结果进行抓取
+	'''
+	samples = ['site:i.mi.com']
+	install_requires = ['pychrome']
+
+
+	def SearchDork(self,target):
+
+		# create a browser instance
+		browser = pychrome.Browser(url="http://127.0.0.1:9222")
+
+		# create a tab
+		tab = browser.new_tab()
+
+		# start the tab
+		tab.start()
+
+		tab.Page.enable()
+
+		# call method
+		tab.Network.enable()
+		tab.Runtime.enable()
+
+		start=1000
+
+		subdomins=[]
+
+		for step in range(0,start+10,10):
+
+			url="https://www.google.com/search?q={}".format(target)
+			url=url+"&start={}".format(step)
+			# stepinfo="step:"+str(step)
+			# logger.info(stepinfo)
+
+			try:
+				# call method with timeout
+				tab.Page.navigate(url=url, _timeout=5)
+				tab.wait(5)
+
+				exp='document.getElementsByClassName("r").length'
+				length= tab.Runtime.evaluate(expression=exp)		
+
+				# google就看报不报错，报错了的话document.getElementsByClassName("r").length是为0的
+				if length['result']['value']==0:
+					break
+
+				#从每一页上抓取url
+				for l in range(0,length['result']['value']):
+					# tab.wait(1)
+					exp1='document.getElementsByClassName("r")[{}].getElementsByTagName("a")[0].href'.format(l)
+					res1= tab.Runtime.evaluate(expression=exp1)
+					logger.info(res1['result']['value'])
+					subdomins.append(res1['result']['value'])
+			except:
+				pass
+
+		tab.stop()
+		browser.close_tab(tab)
+		return subdomins
+
+
+	def _output2file(self,outputPath,msg):
+		with open(outputPath,'a') as f:
+			for m in msg:
+				f.write(m + '\n')
+
+	def _attack(self):
+		return self._verify() 
+
+	def _verify(self):
+		result = {}
+		DorkGrammar = self.url.replace("http://","")
+		subdomins=self.SearchDork(DorkGrammar)
+		tmp=[]
+		for sub in subdomins:
+			url=urlparse.urlparse(sub)
+			if url.scheme+"://"+url.netloc != 'https://www.google.com':
+				tmp.append(url.scheme+"://"+url.netloc)
+		# 去重
+		subdomins=list(set(tmp))
+		result['VerifyInfo'] = {}
+		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
+		outputPath = os.path.join(outputPath,"gdork2result.txt")
+		j=1
+		if subdomins:
+			self._output2file(outputPath,subdomins)	
+			for s in subdomins:
+				t="URL"+str(j)
+				result['VerifyInfo'][t] = s
+				j=j+1
+		outputPathInfo="outpath:"+outputPath
+		logger.log(CUSTOM_LOGGING.SYSINFO, outputPathInfo)
+		return self.parse_output(result)
+
+	def parse_output(self, result):
+		#parse output
+		output = Output(self)
+		if result['VerifyInfo']:
+			output.success(result)
+		else:
+			output.fail('Find nothing or Internet error~')
+		return output
+
+
+register(Dork)

--- a/modules/google-dork.py
+++ b/modules/google-dork.py
@@ -4,12 +4,15 @@
 import os
 import pychrome
 import urlparse
+import tempfile
+import platform
 from pocsuite.api.poc import register
 from pocsuite.api.poc import Output, POCBase
 from pocsuite.lib.core.data import paths,logger
 from pocsuite.lib.core.common import getUnicode
 from pocsuite.lib.core.common import normalizeUnicode
 from pocsuite.lib.core.enums import CUSTOM_LOGGING
+from pocsuite.lib.core.exception import PocsuiteSystemException
 
 
 # 环境配置:
@@ -105,7 +108,25 @@ class Dork(POCBase):
 
 
 	def _output2file(self,outputPath,msg):
-		with open(outputPath,'a') as f:
+
+		if "Windows" in platform.platform():
+			outputPath = outputPath[:4] + outputPath[4:].replace(":", "-")
+
+		if not os.path.isdir(outputPath):
+			try:
+				os.makedirs(outputPath, 0755)
+			except:
+				print "guess what?!"
+
+		recordFile = os.path.join(outputPath, "gdork2result.txt")
+
+		if not os.path.isfile(recordFile):
+			with open(recordFile, "w") as f:
+				for m in msg:
+					f.write(m + '\n')
+			return
+
+		with open(recordFile,'a+') as f:
 			for m in msg:
 				f.write(m + '\n')
 
@@ -125,7 +146,7 @@ class Dork(POCBase):
 		subdomins=list(set(tmp))
 		result['VerifyInfo'] = {}
 		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
-		outputPath = os.path.join(outputPath,"gdork2result.txt")
+		# outputPath = os.path.join(outputPath,"gdork2result.txt")
 		j=1
 		if subdomins:
 			self._output2file(outputPath,subdomins)	

--- a/modules/yahoo-dork.py
+++ b/modules/yahoo-dork.py
@@ -4,6 +4,8 @@
 import os
 import pychrome
 import urlparse
+import tempfile
+import platform
 from pocsuite.api.poc import register
 from pocsuite.api.poc import Output, POCBase
 from pocsuite.lib.core.data import paths,logger
@@ -90,7 +92,25 @@ class Dork(POCBase):
 		return subdomins
 
 	def _output2file(self,outputPath,msg):
-		with open(outputPath,'a') as f:
+
+		if "Windows" in platform.platform():
+			outputPath = outputPath[:4] + outputPath[4:].replace(":", "-")
+
+		if not os.path.isdir(outputPath):
+			try:
+				os.makedirs(outputPath, 0755)
+			except:
+				print "guess what?!"
+
+		recordFile = os.path.join(outputPath, "yahoo2result.txt")
+
+		if not os.path.isfile(recordFile):
+			with open(recordFile, "w") as f:
+				for m in msg:
+					f.write(m + '\n')
+			return
+
+		with open(recordFile,'a+') as f:
 			for m in msg:
 				f.write(m + '\n')
 
@@ -109,7 +129,7 @@ class Dork(POCBase):
 		subdomins=list(set(tmp))
 		result['VerifyInfo'] = {}
 		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
-		outputPath = os.path.join(outputPath,"yahoo2result.txt")
+		# outputPath = os.path.join(outputPath,"yahoo2result.txt")
 		j=1
 		if subdomins:
 			self._output2file(outputPath,subdomins)	

--- a/modules/yahoo-dork.py
+++ b/modules/yahoo-dork.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import pychrome
+import urlparse
+from pocsuite.api.poc import register
+from pocsuite.api.poc import Output, POCBase
+from pocsuite.lib.core.data import paths,logger
+from pocsuite.lib.core.common import getUnicode
+from pocsuite.lib.core.common import normalizeUnicode
+from pocsuite.lib.core.enums import CUSTOM_LOGGING
+
+
+# 环境配置:
+# 	本地配置chrome的headless，执行如下命令:
+# 	headless mode (chrome version >= 59):
+# 	$ google-chrome --headless --disable-gpu --remote-debugging-port=9222
+
+# 	或者直接使用docker
+# 	$ docker pull fate0/headless-chrome
+# 	$ docker run -it --rm --cap-add=SYS_ADMIN -p9222:9222 fate0/headless-chrome
+
+# 	PS:使用google-dork等需要那啥的时候打开ss就好
+
+# 使用说明:
+# 	对目标使用搜索dork语法，程序会返回抓取的域名
+# 	python pocsuite.py -r modules/yahoo-dork.py -u site:i.mi.com --verify
+# 	默认对域名做了去重输出，根据需要可以修改script
+
+
+class Dork(POCBase):
+	vulID = '0'  # ssvid
+	version = '1.0'
+	author = ['z3r0yu']
+	vulDate = '2018-12-22'
+	createDate = '2018-12-22'
+	updateDate = '2018-12-22'
+	references = ['https://zeroyu.xyz/']
+	name = 'yahoo dork'
+	appPowerLink = 'https://search.yahoo.com/'
+	appName = 'yahoo-dork'
+	appVersion = '1'
+	vulType = 'search dork'
+	desc = '''
+	   使用chrome headless对使用yahoo搜索引擎的搜索结果进行抓取
+	'''
+	samples = ['site:i.mi.com']
+	install_requires = ['pychrome']
+
+
+	def SearchDork(self,target):
+
+		browser = pychrome.Browser(url="http://127.0.0.1:9222")
+		tab = browser.new_tab()
+		tab.start()
+		tab.Page.enable()
+		tab.Network.enable()
+		tab.Runtime.enable()
+		step=1
+		subdomins=[]
+		while(1):
+
+			url="https://search.yahoo.com/search?p={}".format(target)
+			url=url+"&b={}&pz=40".format(step)
+			step=step+40
+
+			try:
+				# call method with timeout
+				tab.Page.navigate(url=url, _timeout=5)
+				tab.wait(5)
+
+				exp='document.getElementsByClassName(" ac-algo fz-l ac-21th lh-24").length'
+				length= tab.Runtime.evaluate(expression=exp)		
+
+				if length['result']['value']==0:
+					break
+
+				for l in range(0,length['result']['value']):
+					# tab.wait(1)
+					exp1='document.getElementsByClassName(" ac-algo fz-l ac-21th lh-24")[{}].href'.format(l)
+					res1= tab.Runtime.evaluate(expression=exp1)
+					logger.info(res1['result']['value'])
+					subdomins.append(res1['result']['value'])
+			except:
+				pass
+
+		tab.stop()
+		browser.close_tab(tab)
+		return subdomins
+
+	def _output2file(self,outputPath,msg):
+		with open(outputPath,'a') as f:
+			for m in msg:
+				f.write(m + '\n')
+
+	def _attack(self):
+		return self._verify() 
+
+	def _verify(self):
+		result = {}
+		DorkGrammar = self.url.replace("http://","")
+		subdomins=self.SearchDork(DorkGrammar)
+		tmp=[]
+		for sub in subdomins:
+			url=urlparse.urlparse(sub)
+			tmp.append(url.scheme+"://"+url.netloc)
+		# 去重
+		subdomins=list(set(tmp))
+		result['VerifyInfo'] = {}
+		outputPath = os.path.join(getUnicode(paths.POCSUITE_OUTPUT_PATH), normalizeUnicode(getUnicode(DorkGrammar)))
+		outputPath = os.path.join(outputPath,"yahoo2result.txt")
+		j=1
+		if subdomins:
+			self._output2file(outputPath,subdomins)	
+			for s in subdomins:
+				t="URL"+str(j)
+				result['VerifyInfo'][t] = s
+				j=j+1
+		outputPathInfo="outpath:"+outputPath
+		logger.log(CUSTOM_LOGGING.SYSINFO, outputPathInfo)
+		return self.parse_output(result)
+
+	def parse_output(self, result):
+		#parse output
+		output = Output(self)
+		if result['VerifyInfo']:
+			output.success(result)
+		else:
+			output.fail('Find nothing or Internet error~')
+		return output
+
+
+register(Dork)


### PR DESCRIPTION
模块借助pychrome使用chrome headless对搜索引擎的搜索结果进行抓取

使用简介如下:
-u 参数对应的是搜索引擎的语法，比如使用site:i.mi.com就可以对i.mi.com的子域名进行采集，采集结果会进行保存并输出在output目录下。
python pocsuite.py -r modules/bing-dork.py -u site:i.mi.com --verify

模块基本是实现对达成特定条件的目标URL进行采集，如果想实现特定功能只需稍作修改即可。